### PR TITLE
장바구니, 상세페이지 마크업

### DIFF
--- a/src/components/productDetail/CartModal.tsx
+++ b/src/components/productDetail/CartModal.tsx
@@ -1,0 +1,88 @@
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { useRef } from "react";
+
+interface ICartModalProps {
+  setOpenModal: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const CartModal = ({ setOpenModal }: ICartModalProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  const checkCart = () => {
+    setOpenModal(false);
+    navigate("/cart");
+  };
+
+  const keepShopping = () => {
+    setOpenModal(false);
+  };
+
+  return (
+    <Overlay>
+      <Wrapper ref={modalRef}>
+        선택한 상품이 장바구니에 담겼습니다.
+        <BtnBox>
+          <CheckCart onClick={checkCart}>장바구니 확인</CheckCart>
+          <KeepShopping onClick={keepShopping}>계속 쇼핑하기</KeepShopping>
+        </BtnBox>
+      </Wrapper>
+    </Overlay>
+  );
+};
+
+export default CartModal;
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 1;
+`;
+
+const Wrapper = styled.div`
+  position: absolute;
+  z-index: 2;
+  top: 40%;
+  left: 35%;
+  padding: 15px;
+  width: 30%;
+  height: 20%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+  gap: 10px;
+  border-radius: 10px;
+  background-color: #fff;
+`;
+
+const BtnBox = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+`;
+
+const CheckCart = styled.button`
+  border-radius: 10px;
+  width: 100%;
+  font-size: 14px;
+  font-weight: 600;
+  color: #364fc7;
+  background-color: #dbe4ff;
+  padding: 10px;
+`;
+
+const KeepShopping = styled.button`
+  border-radius: 10px;
+  width: 100%;
+  font-size: 14px;
+  font-weight: 600;
+  background-color: #364fc7;
+  color: #fff;
+  padding: 10px;
+`;

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,4 +1,42 @@
+import { useState } from "react";
+import styled from "styled-components";
+
 const Cart = () => {
-  return <div>Cart</div>;
+  const [cartItem, setCartItem] = useState([]);
+  return (
+    <Wrapper>
+      <Title>장바구니</Title>
+      <EmptyCart>장바구니에 담긴 상품이 없습니다.</EmptyCart>
+      <CartBtn>상품을 담아주세요</CartBtn>
+    </Wrapper>
+  );
 };
 export default Cart;
+
+const Wrapper = styled.div`
+  padding: 15px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Title = styled.h1`
+  font-size: 18px;
+`;
+
+const EmptyCart = styled.p`
+  font-size: 18px;
+  font-weight: 500;
+  color: #333;
+`;
+
+const CartBtn = styled.button`
+  border-radius: 10px;
+  width: 100%;
+  font-weight: 700;
+  color: #364fc7;
+  background-color: #dbe4ff;
+  padding: 10px;
+`;

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -1,4 +1,170 @@
+import styled from "styled-components";
+import { useState } from "react";
+import CartModal from "components/productDetail/CartModal";
+import { AiOutlineShoppingCart } from "react-icons/ai";
+import { Action } from "@reduxjs/toolkit";
+
 const ProductDetail = () => {
-  return <div>ProductDetail</div>;
+  const [openModal, setOpenModal] = useState(false);
+
+  const handleClick = () => {
+    setOpenModal(true);
+  };
+
+  return (
+    <Wrapper>
+      <ImgBox />
+      <BankTitle>우리은행 신용대출</BankTitle>
+      <ProductTitle>우리금융인클럽 신용대출</ProductTitle>
+      <AverageBox>
+        <AverageContent>
+          <AverageTitle>평균 금리</AverageTitle>
+          <AverageValue>5.04%</AverageValue>
+        </AverageContent>
+        <AverageContent>
+          <AverageTitle>평균 대출액</AverageTitle>
+          <AverageValue>3,420만원</AverageValue>
+        </AverageContent>
+      </AverageBox>
+      <BtnBox>
+        <LikeBtn>찜하기</LikeBtn>
+        <CartBtn onClick={handleClick}>
+          <AiOutlineShoppingCart />
+          장바구니에 담기
+        </CartBtn>
+        {openModal && <CartModal setOpenModal={setOpenModal} />}
+      </BtnBox>
+      <DetailBox>
+        <DetailBoxTitle>상세정보</DetailBoxTitle>
+        <DetailTitle>대출 금리</DetailTitle>
+        <DetailContent>변동금리(6개월): 최저 6.21%</DetailContent>
+        <DetailTitle>대출 부대 비용</DetailTitle>
+        <DetailContent>변동금리(6개월): 최저 6.21%</DetailContent>
+        <DetailTitle>중도 상환 수수료</DetailTitle>
+        <DetailContent>변동금리(6개월): 최저 6.21%</DetailContent>
+        <DetailTitle>연체이자율</DetailTitle>
+        <DetailContent>변동금리(6개월): 최저 6.21%</DetailContent>
+        {/* <DetailTitle>대출 한도</DetailTitle>
+        <DetailContent>변동금리(6개월): 최저 6.21%</DetailContent>
+        <DetailTitle>신청 방식</DetailTitle>
+        <DetailContent>변동금리(6개월): 최저 6.21%</DetailContent>
+        <DetailTitle>신청 조건</DetailTitle>
+        <DetailContent>변동금리(6개월): 최저 6.21%</DetailContent>
+        <DetailTitle>필요 서류</DetailTitle>
+        <DetailContent>변동금리(6개월): 최저 6.21%</DetailContent> */}
+      </DetailBox>
+    </Wrapper>
+  );
 };
 export default ProductDetail;
+
+const Wrapper = styled.div`
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const ImgBox = styled.div`
+  margin: 10px 15px;
+  font-size: 18px;
+  margin-bottom: 10px;
+  width: 40px;
+  height: 40px;
+  background-image: url("https://cdn.banksalad.com/graphic/color/logo/circle/woori.png");
+  background-size: 100%;
+  background-repeat: no-repeat;
+`;
+
+const BankTitle = styled.h1`
+  padding: 0 15px;
+  font-size: 18px;
+  font-weight: 700;
+`;
+
+const ProductTitle = styled.h2`
+  padding: 0 15px;
+  font-size: 18px;
+  font-weight: 700;
+`;
+
+const AverageBox = styled.div`
+  padding: 0 15px;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+  width: 60%;
+`;
+
+const AverageContent = styled.p`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const AverageTitle = styled.p`
+  font-weight: 600;
+  color: #605e5e;
+`;
+
+const AverageValue = styled.p`
+  font-weight: 800;
+  font-size: 20px;
+`;
+
+const BtnBox = styled.div`
+  padding: 0 15px;
+  margin: 10px 0;
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+`;
+
+const LikeBtn = styled.button`
+  border-radius: 10px;
+  width: 100%;
+  font-weight: 600;
+  color: #364fc7;
+  background-color: #dbe4ff;
+  padding: 10px;
+`;
+
+const CartBtn = styled.button`
+  border-radius: 10px;
+  width: 100%;
+  font-weight: 500;
+  background-color: #364fc7;
+  color: #fff;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+`;
+
+const DetailBox = styled.div`
+  padding: 10px 15px;
+  border-top: 15px solid #b8b5b576;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const DetailBoxTitle = styled.h3`
+  font-weight: 700;
+  font-size: 18px;
+  padding: 10px 0;
+`;
+
+const DetailTitle = styled.h3`
+  font-weight: 600;
+  color: #333;
+  font-size: 15px;
+`;
+
+const DetailContent = styled.p`
+  color: #434242;
+  font-size: 15px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #b8b5b576;
+`;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -18,11 +18,11 @@ const Router = createBrowserRouter(
     <Route>
       <Route path="/" element={<SignIn />} />
       <Route path="/signup" element={<SingUp />} />
+      <Route path="/cart" element={<Cart />} />
+      <Route path="/product/:id" element={<ProductDetail />} />
       <Route element={<Root />}>
         <Route path="/home" element={<Main />} />
         <Route path="/mypage" element={<MyPage />} />
-        <Route path="/cart" element={<Cart />} />
-        <Route path="/product/:id" element={<ProductDetail />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/likes" element={<Likes />} />
       </Route>


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

Close #6
Close #9 

## 작업 내용 (변경 사항)

1. 라우터 수정
장바구니 페이지와 상세페이지 접속 시, 헤더와 푸터가 고정되어 있는 게 부자연스럽게 느껴져 root 안에 있던 해당 페이지들을 밖으로 뺐습니다.

2. 장바구니 마크업
장바구니가 비어있을 경우의 ui를 마크업했습니다. (스타일링은 추후 전체적인 디자인에 맞춰 수정될 예정입니다.)

3. 상품상세페이지 마크업
- 상품 데이터가 없어 하드코딩으로 상세페이지를 마크업했습니다. (스타일링은 추후 전체적인 디자인에 맞춰 수정될 예정입니다.)
- 장바구니 담기 버튼 클릭시 모달창이 뜨며 상품이 장바구니에 추가되었음을 알립니다.
- 모달창은 component폴더에 pageDetail 폴더를 생성하여 CartModal.tsx 컴포넌트를 추가해 작업했습니다.

## 스크린샷

장바구니
<img width="423" alt="스크린샷 2023-02-14 오후 5 00 51" src="https://user-images.githubusercontent.com/103507999/218678246-8e6ea80d-f7af-4007-b7a5-7ace71f73846.png">
상세페이지
<img width="424" alt="스크린샷 2023-02-14 오후 5 01 21" src="https://user-images.githubusercontent.com/103507999/218678281-a027b6a9-339b-43d0-985a-9bf8bd66959e.png">
<img width="423" alt="스크린샷 2023-02-14 오후 5 18 44" src="https://user-images.githubusercontent.com/103507999/218678436-44f56b4a-cfa9-4d6a-836f-1d949fbfb455.png">

## 리뷰 요청 사항
commit 하는 걸 까먹어서 내용이 길어졌어요 .. 다음부터는 기능별로 작업 단위를 나눠 커밋하겠습니다!
