### PR TITLE
Feat: 비회원용 탭 ui 및 경로 연결

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import colors from "constants/colors";
+
+import { BiHomeAlt, BiSearchAlt, BiStar, BiLogInCircle } from "react-icons/bi";
+
+const Footer = () => {
+  const [clickTab, setClickTab] = useState(0);
+
+  const menuContent = [
+    { name: "home", content: <BiHomeAlt />, path: "/" },
+    { name: "search", content: <BiSearchAlt />, path: "/search/null" },
+    { name: "likes", content: <BiStar />, path: "/likes" },
+    { name: "login", content: <BiLogInCircle />, path: "/signin" },
+  ];
+
+  return (
+    <FooterContent>
+      <ul>
+        {menuContent.map((item, i) => (
+          <Link to={item.path} key={item.name}>
+            <li
+              role="presentation"
+              className={i === clickTab ? "tabmenu focused" : "tabmenu"}
+              onClick={() => setClickTab(i)}
+            >
+              {item.content}
+            </li>
+          </Link>
+        ))}
+      </ul>
+    </FooterContent>
+  );
+};
+
+const FooterContent = styled.footer`
+  height: 60px;
+  width: 100%;
+  background-color: #fff;
+  position: absolute;
+  bottom: 0;
+  ul {
+    display: flex;
+    height: 100%;
+    border-top: 1px solid ${colors["GRAY-4"]};
+    box-shadow: 0 -5px 5px -3px ${colors["GRAY-4"]};
+    a {
+      margin: auto;
+      .tabmenu {
+        list-style: none;
+        svg {
+          color: ${colors["INDIGO-1"]};
+          font-size: 30px;
+        }
+      }
+      .focused {
+        list-style: none;
+        svg {
+          color: ${colors["INDIGO-9"]};
+          font-size: 30px;
+        }
+      }
+    }
+  }
+`;
+
+export default Footer;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,3 +1,4 @@
+import Footer from "components/Footer";
 import { Outlet } from "react-router-dom";
 
 const Layout = () => {
@@ -7,7 +8,7 @@ const Layout = () => {
       <main>
         <Outlet />
       </main>
-      <footer>푸터</footer>
+      <Footer />
     </>
   );
 };

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -10,6 +10,15 @@ const colors = {
   "INDIGO-8": "#3B5BDB",
   "INDIGO-9": "#364FC7",
   "GRAY-9": "#212529",
+  "GRAY-8": "#343A40",
+  "GRAY-7": "#495057",
+  "GRAY-6": "#868E96",
+  "GRAY-5": "#ADB5BD",
+  "GRAY-4": "#CED4DA",
+  "GRAY-3": "#DEE2E6",
+  "GRAY-2": "#E9ECEF",
+  "GRAY-1": "#F1F3F5",
+  "GRAY-0": "#F8F9FA",
 };
 
 export default colors;

--- a/src/global/globalStyles.ts
+++ b/src/global/globalStyles.ts
@@ -46,6 +46,7 @@ input {
   margin-inline: auto;
   background-color: #fff;
   height: 100vh;
+  position: relative;
 }
 
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -4,7 +4,7 @@ const SignIn = () => {
   return (
     <div>
       SignIn
-      <Link to="/home">home</Link>
+      <Link to="/">home</Link>
     </div>
   );
 };


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

Close #8 

## 작업 내용 (변경 사항)
- 비회원용 ui 적용
- 탭 경로 연결
- colors에 gray 추가

## 스크린샷
![스크린샷 2023-02-14 오후 7 01 22](https://user-images.githubusercontent.com/107393773/218703347-531cd98d-36a1-4d2b-b3b6-c5844ff4124c.png)

![스크린샷 2023-02-14 오후 7 01 15](https://user-images.githubusercontent.com/107393773/218703381-baac06fc-edaf-423e-8178-bc40365852cc.png)

## 리뷰 요청 사항
- 탭이 3개이면 비어보이는 것 같아서 메인페이지(홈) 추가하였습니다
- 회원 / 비회원은 토큰으로 구분할 예정입니다 (회원용에서는 로그인 대신 마이페이지)
- 코드에서 오류가 날 것 같은 부분들 알려주시면 감사하겠습니다 🙇
- 디자인에 재주가 없어서.... 수정할 사항있으시면 알려주세요 😀