### PR TITLE
Feat: 인풋 컴포넌트 분리, 폼 컴포넌트 생성, 마이페이지 공통 레이아웃 추가

### DIFF
--- a/src/components/layout/MypageLayout.tsx
+++ b/src/components/layout/MypageLayout.tsx
@@ -1,0 +1,21 @@
+import Footer from "components/Footer";
+import Header from "components/myPage/Header";
+import { Outlet } from "react-router-dom";
+import styled from "styled-components";
+
+const MyPageLayout = () => {
+  return (
+    <>
+      <Header />
+      <Main>
+        <Outlet />
+      </Main>
+      <Footer />
+    </>
+  );
+};
+
+const Main = styled.main`
+  padding: 0 12px;
+`;
+export default MyPageLayout;

--- a/src/components/myPage/Button.tsx
+++ b/src/components/myPage/Button.tsx
@@ -6,11 +6,12 @@ interface Props {
   primary: boolean;
   children: ReactNode;
   type?: "button" | "submit";
+  disabled?: boolean;
 }
 
-const Button = ({ primary, children, type }: Props) => {
+const Button = ({ primary, children, type, disabled }: Props) => {
   return (
-    <Btn primary={primary} type={type}>
+    <Btn primary={primary} type={type} disabled={disabled}>
       {children}
     </Btn>
   );

--- a/src/components/myPage/Header.tsx
+++ b/src/components/myPage/Header.tsx
@@ -1,0 +1,37 @@
+import colors from "constants/colors";
+import { HiOutlineChevronLeft } from "react-icons/hi2";
+import { Link, useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+const Header = () => {
+  const navigate = useNavigate();
+
+  return (
+    <StyledHeader>
+      <button onClick={() => navigate(-1)}>
+        <HiOutlineChevronLeft />
+      </button>
+
+      <h1>
+        <Link to="/">Home</Link>
+      </h1>
+
+      <div />
+    </StyledHeader>
+  );
+};
+
+const StyledHeader = styled.header`
+  height: 56px;
+  width: 100%;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  svg {
+    font-size: 20px;
+    color: ${colors["GRAY-9"]};
+  }
+`;
+
+export default Header;

--- a/src/components/myPage/TextFiled.tsx
+++ b/src/components/myPage/TextFiled.tsx
@@ -1,0 +1,72 @@
+import colors from "constants/colors";
+import type { ChangeEvent, FocusEvent, RefCallback } from "react";
+import styled, { css } from "styled-components";
+
+interface ITextFiled {
+  id: "username" | "password" | "confirmPassword";
+  label: "이름" | "비밀번호 번경" | "비밀번호 확인";
+  type?: "text" | "password";
+  error?: string;
+  register?: {
+    onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+    ref: RefCallback<HTMLInputElement>;
+    name: string;
+    min?: string | number;
+    max?: string | number;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    required?: boolean;
+    disabled?: boolean;
+  };
+}
+
+const TextFiled = ({ id, label, type, error, register }: ITextFiled) => {
+  return (
+    <>
+      <InputWrapper>
+        <Label htmlFor={id}>{label}</Label>
+        <input {...(register ?? {})} type={type ?? "text"} id={id} />
+      </InputWrapper>
+      {error ? <ErrorMessage>{error}</ErrorMessage> : null}
+    </>
+  );
+};
+export default TextFiled;
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+
+  input {
+    padding: 6px 8px;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    border: 1px solid ${colors["GRAY-3"]};
+    color: ${colors["GRAY-8"]};
+
+    &:focus {
+      border-color: ${colors["INDIGO-3"]};
+    }
+
+    &::placeholder {
+      color: ${colors["GRAY-7"]};
+    }
+  }
+`;
+
+const Label = styled.label<{ focus?: boolean }>`
+  /* ${(props) =>
+    props.focus &&
+    css`
+      color: ${colors["INDIGO-6"]};
+    `} */
+`;
+const ErrorMessage = styled.p`
+  margin-bottom: 8px;
+  font-size: 14px;
+  color: #fa5252;
+`;

--- a/src/components/myPage/UserForm.tsx
+++ b/src/components/myPage/UserForm.tsx
@@ -1,0 +1,96 @@
+import styled from "styled-components";
+import Button from "components/myPage/Button";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import TextFiled from "components/myPage/TextFiled";
+
+const validationSchema = z
+  .object({
+    username: z.string().min(2, "2글자 이상 입력해주세요."),
+    password: z
+      .string()
+      .min(8, "비밀번호는 8자 이상 입력해주세요.")
+      .max(20, "비밀번호는 20자 이하로 입력해주세요.")
+      .regex(
+        /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,20}$/,
+
+        "8자 이상 20자 이하 영어 대·소문자, 숫자, 특수문자!@#$%^&*가 포함되어야 합니다.",
+      ),
+    confirmPassword: z
+      .string()
+      .min(8, "비밀번호는 8자 이상 입력해주세요.")
+      .max(20, "비밀번호는 20자 이하로 입력해주세요.")
+      .regex(
+        /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,20}$/,
+
+        "8자 이상 20자 이하 영어 대·소문자, 숫자, 특수문자!@#$%^&*가 포함되어야 합니다.",
+      ),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    path: ["confirmPassword"],
+    message: "비밀번호가 일치하지 않습니다.",
+  });
+
+export type FormValues = z.infer<typeof validationSchema>;
+
+interface IUserForm {
+  onSubmit: (data: FormValues) => void;
+}
+
+const UserForm = ({ onSubmit }: IUserForm) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(validationSchema),
+  });
+
+  return (
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <TextFiled
+        id="username"
+        label="이름"
+        error={errors.username?.message}
+        register={register("username")}
+      />
+
+      <TextFiled
+        id="password"
+        label="비밀번호 번경"
+        type="password"
+        error={errors.password?.message}
+        register={register("password")}
+      />
+      <TextFiled
+        id="confirmPassword"
+        label="비밀번호 확인"
+        type="password"
+        error={errors.confirmPassword?.message}
+        register={register("confirmPassword")}
+      />
+
+      {/* 선택 정보 추가 해야함 */}
+      <BtnWrapper>
+        <Button primary disabled={isSubmitting} type="submit">
+          {isSubmitting ? <span>제출중...</span> : <span>정보 수정</span>}
+        </Button>
+        <Button primary={false}>회원 탈퇴</Button>
+      </BtnWrapper>
+    </Form>
+  );
+};
+
+const Form = styled.form`
+  margin: 16px 0;
+`;
+
+const BtnWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  /* justify-content: center; */
+  gap: 8px;
+  margin-top: 24px;
+`;
+export default UserForm;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -19,22 +19,22 @@ interface LinkItem {
 const LINK_ITEM: LinkItem[] = [
   {
     icon: <HiOutlineUserCircle />,
-    to: "/user",
+    to: "user",
     label: "회원정보 수정",
   },
   {
     icon: <HiOutlineQueueList />,
-    to: "/order",
+    to: "order",
     label: "신청내역",
   },
   {
     icon: <HiOutlineShoppingCart />,
-    to: "/cart",
+    to: "cart",
     label: "장바구니",
   },
   {
     icon: <HiOutlineHeart />,
-    to: "/likes",
+    to: "likes",
     label: "관심상품",
   },
 ];
@@ -49,7 +49,11 @@ const MyPage = () => {
         <MaleAvatar />
         {/* <FemaleAvatar /> */}
         <div>
-          <span>가나다라</span>님 환영합니다.
+          <Username>가나다라</Username>님 환영합니다.
+          <div>
+            {/* <Button primary={false}>로그아웃</Button> */}
+            <LogOutBtn>로그아웃</LogOutBtn>
+          </div>
         </div>
       </ProfileWrapper>
 
@@ -72,7 +76,7 @@ const MyPage = () => {
 
 const Block = styled.section`
   margin-top: 24px;
-  padding: 0 16px;
+  /* padding: 0 16px; */
 `;
 
 const H1 = styled.h1`
@@ -99,9 +103,25 @@ const ProfileWrapper = styled.div`
   }
 `;
 
+const Username = styled.span`
+  color: ${colors["INDIGO-8"]};
+  font-weight: 600;
+  font-size: 17px;
+`;
+
+const LogOutBtn = styled.button`
+  margin-top: 8px;
+  color: ${colors["RED-9"]};
+  padding: 4px;
+  border: 1px solid ${colors["RED-9"]};
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 400;
+`;
+
 const List = styled.li`
   border-bottom: 1px solid ${colors["GRAY-4"]};
-
+  line-height: 1.4;
   a {
     display: flex;
     align-items: center;
@@ -112,6 +132,10 @@ const List = styled.li`
       display: flex;
       align-items: center;
       gap: 8px;
+    }
+    svg {
+      font-size: 20px;
+      color: ${colors["GRAY-9"]};
     }
   }
 `;

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -1,140 +1,18 @@
-import colors from "constants/colors";
-import styled, { css } from "styled-components";
+import type { FormValues } from "components/myPage/UserForm";
+import UserForm from "components/myPage/UserForm";
+import type { FormEvent } from "react";
 import { useState } from "react";
-import Button from "components/myPage/Button";
-import type { FieldValues } from "react-hook-form";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { zodResolver } from "@hookform/resolvers/zod";
-import * as yup from "yup";
-import { z } from "zod";
-
-const schema = yup.object().shape({
-  username: yup
-    .string()
-    .min(2, "2 글자 이상으로 작성해주세요")
-    .required("이름을 입력해주세요"),
-  oldPassword: yup
-    .string()
-    .min(8, "비밀번호는 8자 이상 입력해주세요")
-    .max(20, "비밀번호는 20자 이하로 입력해주세요")
-    .matches(
-      /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,20}$/,
-      "8자 이상 20자 이하 영어 대·소문자, 숫자, 특수문자!@#$%^&*가 포함되어야 합니다.",
-    )
-    .required("비밀번호를 입력해주세요"),
-  newPassword: yup
-    .string()
-    .oneOf([yup.ref("oldPassword")], "비밀번호가 일치하지 않습니다.")
-    .required("비밀번호를 입력해주세요"),
-});
-
-const validationSchema = z
-  .object({
-    username: z.string().min(2, "2 글자 이상으로 입력해주세요"),
-    password: z
-      .string()
-      .min(8, "비밀번호는 8자 이상 입력해주세요")
-      .max(20, "비밀번호는 20자 이하로 입력해주세요")
-      .regex(
-        /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,20}$/,
-
-        "8자 이상 20자 이하 영어 대·소문자, 숫자, 특수문자!@#$%^&*가 포함되어야 합니다.",
-      ),
-    confirmPassword: z
-      .string()
-      .min(8, "비밀번호는 8자 이상 입력해주세요")
-      .max(20, "비밀번호는 20자 이하로 입력해주세요")
-      .regex(
-        /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,20}$/,
-
-        "8자 이상 20자 이하 영어 대·소문자, 숫자, 특수문자!@#$%^&*가 포함되어야 합니다.",
-      ),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    path: ["confirmPassword"],
-    message: "비밀번호가 일치하지 않습니다.",
-  });
-
-// interface FormValues {
-//   username: string;
-//   password: string;
-//   confirmPassword: string;
-// }
-
-type FormValues = z.infer<typeof validationSchema>;
+import styled from "styled-components";
 
 const User = () => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<FormValues>({
-    resolver: zodResolver(validationSchema),
-  });
-
-  const onSubmit = (data: FieldValues) => {
+  const onSubmit = (data: FormValues) => {
     console.log(data);
   };
 
-  console.log(errors);
-
-  const [focused, setFocused] = useState(false);
-  const onFocus = () => setFocused(true);
-  const onBlur = () => setFocused(false);
   return (
     <Block>
       <H1>회원정보 수정</H1>
-
-      <Form onSubmit={handleSubmit(onSubmit)}>
-        {/* 컴포넌트 분리해야 개별 포커싱 */}
-        <InputWrapper>
-          <Label htmlFor="username" focused={focused}>
-            이름
-          </Label>
-          <input
-            {...register("username")}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            type="text"
-            id="username"
-          />
-        </InputWrapper>
-        <ErrorMessage>{errors.username?.message}</ErrorMessage>
-        <InputWrapper>
-          <Label htmlFor="password" focused={focused}>
-            비밀번호 변경
-          </Label>
-          <input
-            {...register("password")}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            type="password"
-            id="password"
-          />
-        </InputWrapper>
-        <ErrorMessage>{errors.password?.message}</ErrorMessage>
-        <InputWrapper>
-          <Label htmlFor="newPassword" focused={focused}>
-            비밀번호 확인
-          </Label>
-          <input
-            {...register("confirmPassword")}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            type="password"
-            id="newPassword"
-          />
-        </InputWrapper>
-        <ErrorMessage>{errors.confirmPassword?.message}</ErrorMessage>
-        {/* 선택 정보 추가 해야함 */}
-        <BtnWrapper>
-          <Button primary type="submit">
-            정보 수정
-          </Button>
-          <Button primary={false}>회원 탈퇴</Button>
-        </BtnWrapper>
-      </Form>
+      <UserForm onSubmit={onSubmit} />
     </Block>
   );
 };
@@ -148,59 +26,6 @@ const H1 = styled.h1`
   padding-bottom: 12px;
   position: relative;
   display: inline-block;
-`;
-
-const Form = styled.form`
-  margin: 16px 0;
-`;
-
-const InputWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-bottom: 12px;
-
-  input {
-    padding: 6px 8px;
-    border-radius: 4px;
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    border: 1px solid ${colors["GRAY-3"]};
-    color: ${colors["GRAY-8"]};
-
-    &:focus {
-      border-color: ${colors["INDIGO-3"]};
-    }
-
-    &::placeholder {
-      color: ${colors["GRAY-7"]};
-    }
-  }
-
-  input:focus + label {
-    color: ${colors["INDIGO-3"]};
-  }
-`;
-
-const Label = styled.label<{ focused?: boolean }>`
-  /* ${(props) =>
-    props.focused &&
-    css`
-      color: ${colors["INDIGO-6"]};
-    `} */
-`;
-
-const ErrorMessage = styled.p`
-  margin-bottom: 8px;
-  font-size: 14px;
-  color: #fa5252;
-`;
-
-const BtnWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  /* justify-content: center; */
-  gap: 8px;
-  margin-top: 24px;
 `;
 
 export default User;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -29,11 +29,11 @@ const Router = createBrowserRouter(
         <Route path="/" element={<Main />} />
         <Route path="/search/:value" element={<Search />} />
       </Route>
-      <Route element={<MyPageLayout />}>
+      <Route path="/mypage" element={<MyPageLayout />}>
         <Route path="/mypage" element={<MyPage />} />
-        <Route path="/user" element={<User />} />
-        <Route path="/order" element={<Order />} />
-        <Route path="/likes" element={<Likes />} />
+        <Route path="user" element={<User />} />
+        <Route path="order" element={<Order />} />
+        <Route path="likes" element={<Likes />} />
       </Route>
       <Route path="*" element={<NotFound />} />
     </Route>,

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -16,6 +16,7 @@ import Search from "pages/Search";
 import NotFound from "pages/NotFound";
 import Order from "pages/Order";
 import User from "pages/User";
+import MyPageLayout from "components/layout/MypageLayout";
 
 const Router = createBrowserRouter(
   createRoutesFromElements(
@@ -25,10 +26,10 @@ const Router = createBrowserRouter(
       <Route path="/cart" element={<Cart />} />
       <Route path="/product/:id" element={<ProductDetail />} />
       <Route element={<Root />}>
-        <Route path="/home" element={<Main />} />
-        <Route path="/mypage" element={<MyPage />} />
         <Route path="/" element={<Main />} />
         <Route path="/search/:value" element={<Search />} />
+      </Route>
+      <Route element={<MyPageLayout />}>
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/user" element={<User />} />
         <Route path="/order" element={<Order />} />


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

Close #31 
Close #34 

## 작업 내용 (변경 사항)

- User 페이지에서 관리하던 인풋과 폼을 컴포넌트로 분리했습니다.
- auth 기능에서 재사용할 수 있을지도..?
- 마이페이지 공통 레이아웃을 추가 했습니다.
- 일단 임시로 추가하긴 했는데, 나중에 path를 이용해서 헤더만 바꾸는 식으로 해도 좋을 거 같아요
  - 푸터 active를 체크를 못하더라고요?

## 스크린샷
![image](https://user-images.githubusercontent.com/83855636/219561501-964b7c6a-0146-4565-927c-99afcbd669e1.png)


## 리뷰 요청 사항
